### PR TITLE
URLField improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HTML5 field classes for Silverstripe
 
-This is module *under development* to provide a set of bare bones HTML5 inputs with no Javascript or CSS.
+This module provides a set of bare bones HTML5 inputs with no Javascript or CSS.
 
 You can use these fields in your projects as-is or extend them to provide additional features or shims.
 

--- a/docs/en/002_inputs.md
+++ b/docs/en/002_inputs.md
@@ -20,6 +20,8 @@ $fields->addFieldToTab(
 ```html
 <input type="color" id="field" name="field" value="#00bedf">
 ```
+If your markdown interpreter renders this, you will see an HTML colour picker field:
+
 <input type="color" id="field" name="field" value="#00bedf">
 
 <hr>
@@ -41,6 +43,8 @@ With a `<datalist>`, although note that browsers will allow other colours to be 
 </datalist>
 ```
 
+Again, an HTML example:
+
 <input type="color" id="field" name="field" value="#00bedf" list="colours">
 <datalist id="colours">
   <option>#ff0000</option>
@@ -49,3 +53,27 @@ With a `<datalist>`, although note that browsers will allow other colours to be 
   <option>#ffff00</option>
   <option>#00ffff</option>
 </datalist>
+
+<hr>
+
+No need for fancy JS pickers when the browser can do it just as easily. Non supporting browsers will fallback to a text input field.
+
+## URL Field
+
+A good starting point is the `URLFieldTest` class:
+
+```php
+$url = 'ftp://www.example.com/path?foo=bar';
+$field = UrlField::create('TestURL', 'Test URL', $url);
+$pattern = "^ftp://.+\.com";
+$phpPattern = "|^ftp://.+\.com|";
+$field->setPattern($pattern, $phpPattern);
+```
+
+## Methods available
+
++ `setRequiredParts` - provide an array of URL parts the URL must have for validation to pass, the values being the keys from `parse_url()`
++ `setPattern` - set complex and mystifying URL regular expression patterns in both JS and PHP
++ `setSchemes` - set an array of schemes that the URL must start with (eg. `['blob', 'dict', 'dns']`)
++ `restrictToHttp` - shorthand method, the URL must start with http:// OR https://
++ `restrictToHttps` - shorthand method, the URL must start with https://

--- a/src/Forms/TelField.php
+++ b/src/Forms/TelField.php
@@ -17,13 +17,6 @@ class TelField extends TextField {
     protected $inputType = 'tel';
 
     /**
-     * @inheritdoc
-     */
-    public function Type() {
-        return 'text tel';
-    }
-
-    /**
      * TODO: use libphonenumber to validate the number
      *
      * @param Validator $validator

--- a/src/Forms/UrlField.php
+++ b/src/Forms/UrlField.php
@@ -3,6 +3,7 @@
 namespace Codem\Utilities\HTML5;
 
 use Silverstripe\Forms\TextField;
+use SilverStripe\ORM\ValidationResult;
 
 /**
  * Provides a URL input field
@@ -13,9 +14,29 @@ class UrlField extends TextField {
     use Datalist;
     use Pattern;
 
+    /**
+     * @var string
+     */
     protected $template = "Codem/Utilities/HTML5/UrlField";
 
+    /**
+     * @var string
+     */
     protected $inputType = 'url';
+
+    /**
+     * An array of schemes that must be matched
+     * @var array
+     */
+    protected $schemes = [];
+
+    /**
+     * Parts of the URL that must be present
+     * One or more of the potential keys within the return array of parse_url()
+     * By default the field requires a scheme and host to be present
+     * @var array
+     */
+    protected $requiredParts = ['scheme','host'];
 
     /**
      * TODO: use domain validation to validate the URL
@@ -26,6 +47,124 @@ class UrlField extends TextField {
      */
     public function validate($validator)
     {
+        $value = $this->dataValue();
+        if(empty($value)) {
+            // Use RequiredFields to validate empty submissions
+            return true;
+        }
+
+        $check = $this->validateValueAgainstPattern();
+        if($check != 1) {
+            // validation failed
+            $validator->validationError(
+                $this->getName(),
+                _t(
+                    'Codem\\Utilities\\HTML5\\UrlField.FAILED_PATTERN_VALIDATION',
+                    'The URL provided does not match the format requested'
+                ),
+                ValidationResult::TYPE_ERROR
+            );
+            // Pattern validation failed
+            return false;
+        }
+
+        // Check for valid URL format
+        if(!$this->parseURL($this->dataValue())) {
+            $validator->validationError(
+                $this->getName(),
+                _t(
+                    'Codem\\Utilities\\HTML5\\UrlField.FAILED_URL_PARSE',
+                    'The value provided does not appear to be a well-formed URL'
+                ),
+                ValidationResult::TYPE_ERROR
+            );
+            return false;
+        }
+
         return true;
+    }
+
+    public function setRequiredParts(array $requiredParts) {
+        $this->requiredParts = $requiredParts;
+        return $this;
+    }
+
+    /**
+     * Parse a possible URL string
+     * If the second parameter is provided, the URL must have those parts
+     */
+    public function parseURL(string $url) : bool {
+        if($url == '') {
+            // an empty URL is a valid URL
+            return true;
+        }
+        // Check for valid URL format
+        $parts = parse_url($url);
+        if(empty($this->requiredParts)) {
+            return !empty($parts);
+        }  else {
+            // ensure all of the required parts are present in all of the keys
+            $result = array_intersect($this->requiredParts, array_keys($parts));
+            sort($result);
+            sort($this->requiredParts);
+            return $result == $this->requiredParts;
+        }
+    }
+
+    /**
+     * Schemes are set by calling restrictToSchemes
+     */
+    protected function setSchemes(array $schemes) {
+        $this->schemes = $schemes;
+        return $this;
+    }
+
+    public function getSchemes() {
+        return $this->schemes;
+    }
+
+    /**
+     * Restrict to http (and https) protocols
+     */
+    public function restrictToHttp() {
+        $this->restrictToSchemes(["https","http"]);
+        $this->setAttribute(
+            'placeholder',
+            _t(
+                'Codem\\Utilities\\HTML5\\UrlField.PLACEHOLDER_SCHEME_HTTP',
+                'Provide a URL starting with http:// or https://'
+            )
+        );
+        return $this;
+    }
+
+    /**
+     * Restrict to URLs beginning with https://
+     */
+    public function restrictToHttps() {
+        return $this->restrictToSchemes(["https"]);
+    }
+
+    /**
+     * Restrict to URLs beginning with the provided scheme
+     */
+    public function restrictToSchemes(array $schemes) {
+        $this->setSchemes($schemes);
+        $schemesString = implode("://, ", $schemes)  . "://";
+        $this->setAttribute(
+            'placeholder',
+            _t(
+                'Codem\\Utilities\\HTML5\\UrlField.PLACEHOLDER_SCHEME',
+                'Please provide a URL starting with {schemes}',
+                [
+                    'schemes' => $schemesString
+                ]
+            )
+        );
+        // JS pattern
+        $pattern = "^(" . implode("|", $schemes) . ")://.*";
+        // PHP
+        $phpPattern = "/^(" . implode("|", $schemes) . "):\/\/.*/";
+        return $this->setPattern($pattern, $phpPattern);
     }
 }

--- a/src/Traits/Pattern.php
+++ b/src/Traits/Pattern.php
@@ -5,17 +5,52 @@ namespace Codem\Utilities\HTML5;
 trait Pattern {
 
     /**
+     * @var string
+     */
+    protected $phpPattern = '';
+
+    /**
      * Set a string pattern value for the pattern attribute
-     * @param string $id optional datalist id attribute
+     * @param string $pattern
+     * @param string $phpPattern optional regular expression for use in server side validation. If not provided, $pattern will be used. Helpful when the JS RegExp won't compile.
      * @return FormField
      */
-    public function setPattern(string $pattern) {
+    public function setPattern(string $pattern, string $phpPattern = '') {
         $this->setAttribute('pattern', $pattern);
+        $this->phpPattern = $phpPattern;
         return $this;
     }
 
+    /**
+     * @return string|null
+     */
     public function getPattern() {
         return $this->getAttribute('pattern');
+    }
+
+    /**
+     * @return string
+     */
+    public function getPHPPattern() : string {
+        return $this->phpPattern;
+    }
+
+    /**
+     * Validate the value against the provided php regex pattern
+     * When providing a pattern, you must provide the corresponding php regular expression
+     */
+    public function validateValueAgainstPattern() : bool {
+        $pattern = $this->phpPattern;
+        if(!$pattern) {
+            $pattern = $this->getPattern();
+            if(!$pattern) {
+                // no pattern
+                return true;
+            }
+        }
+        $value = $this->dataValue();
+        $check = preg_match($pattern, $value, $matches);
+        return $check === 1;
     }
 
 }

--- a/tests/ColourInputTest.php
+++ b/tests/ColourInputTest.php
@@ -5,8 +5,7 @@ namespace Codem\Utilities\HTML5;
 use SilverStripe\Dev\SapphireTest;
 
 /**
- * Tests for mailgun-sync, see README.md for more
- * @author James Ellis <james.ellis@dpc.nsw.gov.au>
+ * ColourField input test
  */
 
 class ColourInputTest extends SapphireTest

--- a/tests/URLFieldTest.php
+++ b/tests/URLFieldTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Codem\Utilities\HTML5;
+
+use Codem\Utilities\HTML5\UrlField;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\RequiredFields;
+
+/**
+ * URLField input test
+ */
+
+class URLFieldTest extends SapphireTest
+{
+    protected $usesDatabase = false;
+
+    public function testHttpScheme() {
+        $url = 'ftp://www.example.com/path?foo=bar';
+        $field = UrlField::create('TestURL', 'Test URL', $url);
+        $field->restrictToHttp();
+        $schemes = $field->getSchemes();
+        $this->assertContains('http', $schemes);
+        $this->assertContains('https', $schemes);
+
+        $pattern = $field->getPattern();
+        $phpPattern = $field->getPHPPattern();
+
+        $expectedPattern = "^(https|http)://.*";
+        $expectedPhpPattern = "/^(https|http):\/\/.*/";
+        $this->assertEquals($expectedPattern, $pattern);
+        $this->assertEquals($expectedPhpPattern, $expectedPhpPattern);
+
+        $validator = new RequiredFields();
+        $result = $field->validate($validator);
+        $this->assertFalse($result, "Field should not validate");
+
+    }
+
+    public function testHttpsScheme() {
+        $url = 'http://www.example.com/path?foo=bar';
+        $field = UrlField::create('TestURL', 'Test URL', $url);
+        $field->restrictToHttps();
+        $schemes = $field->getSchemes();
+        $this->assertNotContains('http', $schemes);
+        $this->assertContains('https', $schemes);
+
+        $pattern = $field->getPattern();
+        $phpPattern = $field->getPHPPattern();
+
+        $expectedPattern = "^(https)://.*";
+        $expectedPhpPattern = "/^(https):\/\/.*/";
+        $this->assertEquals($expectedPattern, $pattern);
+        $this->assertEquals($expectedPhpPattern, $expectedPhpPattern);
+
+        $validator = new RequiredFields();
+        $result = $field->validate($validator);
+        $this->assertFalse($result, "Field should not validate");
+    }
+
+    public function testRequiredParts() {
+        $url = 'https://www.example.com/path?foo=bar';
+        $field = UrlField::create('TestURL', 'Test URL', $url);
+        $field->setRequiredParts(['scheme','query']);
+        $result = $field->parseURL($url);
+
+        $this->assertTrue($result, 'parseURL failed to pick up scheme and query in valid URL');
+    }
+
+    public function testRequiredPartsMissing() {
+        $url = 'https://www.example.com/path?foo=bar';
+        $field = UrlField::create('TestURL', 'Test URL', $url);
+        $field->setRequiredParts(['scheme','query', 'fragment']);
+        $result = $field->parseURL($url);
+
+        $this->assertFalse($result, 'parseURL failed when finding fragment in URL with no fragment');
+    }
+
+    public function testNonStandardSchemes() {
+        $url = 'https://www.example.com/path?foo=bar';
+        $schemes = ['blob','chrome','dict'];
+        $field = UrlField::create('TestURL', 'Test URL', $url);
+        $field->restrictToSchemes($schemes);
+        $resultSchemes = $field->getSchemes();
+        $this->assertEquals($schemes, $resultSchemes);
+
+        $validator = new RequiredFields();
+        $result = $field->validate($validator);
+        $this->assertFalse($result, "Field should not validate");
+
+    }
+
+    public function testWithPattern() {
+        $url = 'ftp://www.example.com/path?foo=bar';
+        $field = UrlField::create('TestURL', 'Test URL', $url);
+        $pattern = "^ftp://.+\.com";
+        $phpPattern = "|^ftp://.+\.com|";
+        $field->setPattern($pattern, $phpPattern);
+        $validator = new RequiredFields();
+        $result = $field->validate($validator);
+        $this->assertTrue($result, "Field should validate for url {$url}");
+    }
+
+    public function testWithPatternToFail() {
+        $url = 'ftp://www.example.org/path?foo=bar';
+        $field = UrlField::create('TestURL', 'Test URL', $url);
+        $pattern = "^ftp://.+\.example\.com";
+        $phpPattern = "|^ftp://.+\.example\.com|";
+        $field->setPattern($pattern, $phpPattern);
+        $validator = new RequiredFields();
+        $result = $field->validate($validator);
+        $this->assertFalse($result, "Field should not validate for url {$url}");
+    }
+
+}


### PR DESCRIPTION
## Changes

+ Pattern trait: provide ability to set separate PHP regular expression, in addition to pattern for that element attribute
+ Pattern trait: validate pattern server side
+ UrlField: restrictToHttp - shorthand method, restrict to http and https schemes
+ UrlField: restrictToHttps - shorthand method, restrict to https schemes
+ UrlField: restrictToSchemes - shorthand method, restrict URL to starting with one or more schemes
+ UrlField: setRequiredParts - URL must contain all of the parts set
+ General documentation update to support changes
+ Add UrlField tests